### PR TITLE
Remember bound framebuffer to avoid glGetInteger use.

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Framebuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Framebuffer.cs
@@ -20,9 +20,10 @@ namespace Ryujinx.Graphics.OpenGL
             _colors = new TextureView[8];
         }
 
-        public void Bind()
+        public int Bind()
         {
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, Handle);
+            return Handle;
         }
 
         public void AttachColor(int index, TextureView color)

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -23,8 +23,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
             Extents2D   dstRegion,
             bool        linearFilter)
         {
-            int oldReadFramebufferHandle = GL.GetInteger(GetPName.ReadFramebufferBinding);
-            int oldDrawFramebufferHandle = GL.GetInteger(GetPName.DrawFramebufferBinding);
+            (int oldDrawFramebufferHandle, int oldReadFramebufferHandle) = ((Pipeline)_renderer.Pipeline).GetBoundFramebuffers();
 
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, GetSrcFramebufferLazy());
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, GetDstFramebufferLazy());

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -28,6 +28,9 @@ namespace Ryujinx.Graphics.OpenGL
         private bool _depthTest;
         private bool _hasDepthBuffer;
 
+        private int _boundDrawFramebuffer;
+        private int _boundReadFramebuffer;
+
         private TextureBase _unit0Texture;
 
         private ClipOrigin _clipOrigin;
@@ -956,10 +959,16 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 _framebuffer = new Framebuffer();
 
-                _framebuffer.Bind();
+                int boundHandle = _framebuffer.Bind();
+                _boundDrawFramebuffer = _boundReadFramebuffer = boundHandle;
 
                 GL.Enable(EnableCap.FramebufferSrgb);
             }
+        }
+
+        internal (int drawHandle, int readHandle) GetBoundFramebuffers()
+        {
+            return (_boundDrawFramebuffer, _boundReadFramebuffer);
         }
 
         private void UpdateDepthTest()

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -44,8 +44,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             bool[] oldFramebufferColorWritemask = new bool[4];
 
-            int oldReadFramebufferHandle = GL.GetInteger(GetPName.ReadFramebufferBinding);
-            int oldDrawFramebufferHandle = GL.GetInteger(GetPName.DrawFramebufferBinding);
+            (int oldDrawFramebufferHandle, int oldReadFramebufferHandle) = ((Pipeline)_renderer.Pipeline).GetBoundFramebuffers();
 
             GL.GetBoolean(GetIndexedPName.ColorWritemask, drawFramebuffer, oldFramebufferColorWritemask);
 


### PR DESCRIPTION
glGetInteger seems to sync with GPU which is less than ideal, and slowing down texture copies.