### PR TITLE
Implement Zero-Configuration Resolution Scaling (#1365)

### DIFF
--- a/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
@@ -13,9 +13,19 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 10;
+        public const int CurrentVersion = 11;
 
         public int Version { get; set; }
+
+        /// <summary>
+        /// Resolution Scale. An integer scale applied to applicable render targets. Values 1-4, or -1 to use a custom floating point scale instead.
+        /// </summary>
+        public int ResScale { get; set; }
+
+        /// <summary>
+        /// Custom Resolution Scale. A custom floating point scale applied to applicable render targets. Only active when Resolution Scale is -1.
+        /// </summary>
+        public float ResScaleCustom { get; set; }
 
         /// <summary>
         /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.

--- a/Ryujinx.Graphics.GAL/Format.cs
+++ b/Ryujinx.Graphics.GAL/Format.cs
@@ -162,11 +162,21 @@ namespace Ryujinx.Graphics.GAL
 
     public static class FormatExtensions
     {
+        /// <summary>
+        /// Checks if the texture format is an ASTC format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an ASTC format, false otherwise</returns>
         public static bool IsAstc(this Format format)
         {
             return format.IsAstcUnorm() || format.IsAstcSrgb();
         }
 
+        /// <summary>
+        /// Checks if the texture format is an ASTC Unorm format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an ASTC Unorm format, false otherwise</returns>
         public static bool IsAstcUnorm(this Format format)
         {
             switch (format)
@@ -191,6 +201,11 @@ namespace Ryujinx.Graphics.GAL
             return false;
         }
 
+        /// <summary>
+        /// Checks if the texture format is an ASTC SRGB format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an ASTC SRGB format, false otherwise</returns>
         public static bool IsAstcSrgb(this Format format)
         {
             switch (format)
@@ -209,6 +224,132 @@ namespace Ryujinx.Graphics.GAL
                 case Format.Astc10x10Srgb:
                 case Format.Astc12x10Srgb:
                 case Format.Astc12x12Srgb:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the texture format is a depth, stencil or depth-stencil format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the format is a depth, stencil or depth-stencil format, false otherwise</returns>
+        public static bool IsDepthOrStencil(this Format format)
+        {
+            switch (format)
+            {
+                case Format.D16Unorm:
+                case Format.D24UnormS8Uint:
+                case Format.D24X8Unorm:
+                case Format.D32Float:
+                case Format.D32FloatS8Uint:
+                case Format.S8Uint:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the texture format is an unsigned integer color format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an unsigned integer color format, false otherwise</returns>
+        public static bool IsUint(this Format format)
+        {
+            switch (format)
+            {
+                case Format.R8Uint:
+                case Format.R16Uint:
+                case Format.R32Uint:
+                case Format.R8G8Uint:
+                case Format.R16G16Uint:
+                case Format.R32G32Uint:
+                case Format.R8G8B8Uint:
+                case Format.R16G16B16Uint:
+                case Format.R32G32B32Uint:
+                case Format.R8G8B8A8Uint:
+                case Format.R16G16B16A16Uint:
+                case Format.R32G32B32A32Uint:
+                case Format.R10G10B10A2Uint:
+                case Format.R8G8B8X8Uint:
+                case Format.R16G16B16X16Uint:
+                case Format.R32G32B32X32Uint:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the texture format is a signed integer color format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is a signed integer color format, false otherwise</returns>
+        public static bool IsSint(this Format format)
+        {
+            switch (format)
+            {
+                case Format.R8Sint:
+                case Format.R16Sint:
+                case Format.R32Sint:
+                case Format.R8G8Sint:
+                case Format.R16G16Sint:
+                case Format.R32G32Sint:
+                case Format.R8G8B8Sint:
+                case Format.R16G16B16Sint:
+                case Format.R32G32B32Sint:
+                case Format.R8G8B8A8Sint:
+                case Format.R16G16B16A16Sint:
+                case Format.R32G32B32A32Sint:
+                case Format.R10G10B10A2Sint:
+                case Format.R8G8B8X8Sint:
+                case Format.R16G16B16X16Sint:
+                case Format.R32G32B32X32Sint:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the texture format is an integer color format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an integer color format, false otherwise</returns>
+        public static bool IsInteger(this Format format)
+        {
+            return format.IsUint() || format.IsSint();
+        }
+
+        /// <summary>
+        /// Checks if the texture format only has one component.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format only has one component, false otherwise</returns>
+        public static bool HasOneComponent(this Format format)
+        {
+            switch (format)
+            {
+                case Format.R8Unorm:
+                case Format.R8Snorm:
+                case Format.R8Uint:
+                case Format.R8Sint:
+                case Format.R16Float:
+                case Format.R16Unorm:
+                case Format.R16Snorm:
+                case Format.R16Uint:
+                case Format.R16Sint:
+                case Format.R32Float:
+                case Format.R32Uint:
+                case Format.R32Sint:
+                case Format.R8Uscaled:
+                case Format.R8Sscaled:
+                case Format.R16Uscaled:
+                case Format.R16Sscaled:
+                case Format.R32Uscaled:
+                case Format.R32Sscaled:
                     return true;
             }
 

--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -54,6 +54,8 @@ namespace Ryujinx.Graphics.GAL
 
         void SetRasterizerDiscard(bool discard);
 
+        void SetRenderTargetScale(float scale);
+
         void SetRenderTargetColorMasks(ReadOnlySpan<uint> componentMask);
 
         void SetRenderTargets(ITexture[] colors, ITexture depthStencil);
@@ -84,5 +86,7 @@ namespace Ryujinx.Graphics.GAL
         bool TryHostConditionalRendering(ICounterEvent value, ulong compare, bool isEqual);
         bool TryHostConditionalRendering(ICounterEvent value, ICounterEvent compare, bool isEqual);
         void EndHostConditionalRendering();
+
+        void UpdateRenderScale(ShaderStage stage, int textureCount);
     }
 }

--- a/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Graphics.GAL
         IProgram CreateProgram(IShader[] shaders);
 
         ISampler CreateSampler(SamplerCreateInfo info);
-        ITexture CreateTexture(TextureCreateInfo info);
+        ITexture CreateTexture(TextureCreateInfo info, float scale);
 
         void DeleteBuffer(BufferHandle buffer);
 

--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -4,6 +4,10 @@ namespace Ryujinx.Graphics.GAL
 {
     public interface ITexture : IDisposable
     {
+        int Width { get; }
+        int Height { get; }
+        float ScaleFactor { get; }
+
         void CopyTo(ITexture destination, int firstLayer, int firstLevel);
         void CopyTo(ITexture destination, Extents2D srcRegion, Extents2D dstRegion, bool linearFilter);
 

--- a/Ryujinx.Graphics.Gpu/Engine/Compute.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute.cs
@@ -132,11 +132,11 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 if (descriptor.IsBindless)
                 {
-                    textureBindings[index] = new TextureBindingInfo(target, descriptor.CbufOffset, descriptor.CbufSlot);
+                    textureBindings[index] = new TextureBindingInfo(target, descriptor.CbufOffset, descriptor.CbufSlot, descriptor.Flags);
                 }
                 else
                 {
-                    textureBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex);
+                    textureBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex, descriptor.Flags);
                 }
             }
 
@@ -150,7 +150,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 Target target = GetTarget(descriptor.Type);
 
-                imageBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex);
+                imageBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex, descriptor.Flags);
             }
 
             TextureManager.SetComputeImages(imageBindings);

--- a/Ryujinx.Graphics.Gpu/Engine/MethodClear.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodClear.cs
@@ -26,7 +26,9 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 UpdateScissorState(state);
             }
 
-            UpdateRenderTargetState(state, useControl: false);
+            int index = (argument >> 6) & 0xf;
+
+            UpdateRenderTargetState(state, useControl: false, singleUse: index);
 
             TextureManager.CommitGraphicsBindings();
 
@@ -34,8 +36,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
             bool clearStencil = (argument & 2) != 0;
 
             uint componentMask = (uint)((argument >> 2) & 0xf);
-
-            int index = (argument >> 6) & 0xf;
 
             if (componentMask != 0)
             {

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -313,7 +313,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
         /// </summary>
         /// <param name="state">Current GPU state</param>
         /// <param name="useControl">Use draw buffers information from render target control register</param>
-        private void UpdateRenderTargetState(GpuState state, bool useControl)
+        /// <param name="singleUse">If this is not -1, it indicates that only the given indexed target will be used.</param> 
+        private void UpdateRenderTargetState(GpuState state, bool useControl, int singleUse = -1)
         {
             var rtControl = state.Get<RtControl>(MethodOffset.RtControl);
 
@@ -324,6 +325,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
             int samplesInX = msaaMode.SamplesInX();
             int samplesInY = msaaMode.SamplesInY();
 
+            bool changedScale = false;
+
             for (int index = 0; index < Constants.TotalRenderTargets; index++)
             {
                 int rtIndex = useControl ? rtControl.UnpackPermutationIndex(index) : index;
@@ -332,14 +335,14 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 if (index >= count || !IsRtEnabled(colorState))
                 {
-                    TextureManager.SetRenderTargetColor(index, null);
+                    changedScale |= TextureManager.SetRenderTargetColor(index, null);
 
                     continue;
                 }
 
                 Texture color = TextureManager.FindOrCreateTexture(colorState, samplesInX, samplesInY);
 
-                TextureManager.SetRenderTargetColor(index, color);
+                changedScale |= TextureManager.SetRenderTargetColor(index, color);
 
                 if (color != null)
                 {
@@ -359,7 +362,16 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 depthStencil = TextureManager.FindOrCreateTexture(dsState, dsSize, samplesInX, samplesInY);
             }
 
-            TextureManager.SetRenderTargetDepthStencil(depthStencil);
+            changedScale |= TextureManager.SetRenderTargetDepthStencil(depthStencil);
+
+            if (changedScale)
+            {
+                TextureManager.UpdateRenderTargetScale(singleUse);
+                _context.Renderer.Pipeline.SetRenderTargetScale(TextureManager.RenderTargetScale);
+
+                UpdateViewportTransform(state);
+                UpdateScissorState(state);
+            }
 
             if (depthStencil != null)
             {
@@ -394,7 +406,21 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 if (enable)
                 {
-                    _context.Renderer.Pipeline.SetScissor(index, scissor.X1, scissor.Y1, scissor.X2 - scissor.X1, scissor.Y2 - scissor.Y1);
+                    int x = scissor.X1;
+                    int y = scissor.Y1;
+                    int width = scissor.X2 - x;
+                    int height = scissor.Y2 - y;
+
+                    float scale = TextureManager.RenderTargetScale;
+                    if (scale != 1f)
+                    {
+                        x = (int)(x * scale);
+                        y = (int)(y * scale);
+                        width = (int)Math.Ceiling(width * scale);
+                        height = (int)Math.Ceiling(height * scale);
+                    }
+
+                    _context.Renderer.Pipeline.SetScissor(index, x, y, width, height);
                 }
             }
         }
@@ -459,6 +485,15 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 float width  = MathF.Abs(transform.ScaleX) * 2;
                 float height = MathF.Abs(transform.ScaleY) * 2;
+
+                float scale = TextureManager.RenderTargetScale;
+                if (scale != 1f)
+                {
+                    x *= scale;
+                    y *= scale;
+                    width *= scale;
+                    height *= scale;
+                }
 
                 RectangleF region = new RectangleF(x, y, width, height);
 
@@ -909,11 +944,11 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                     if (descriptor.IsBindless)
                     {
-                        textureBindings[index] = new TextureBindingInfo(target, descriptor.CbufSlot, descriptor.CbufOffset);
+                        textureBindings[index] = new TextureBindingInfo(target, descriptor.CbufSlot, descriptor.CbufOffset, descriptor.Flags);
                     }
                     else
                     {
-                        textureBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex);
+                        textureBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex, descriptor.Flags);
                     }
                 }
 
@@ -927,7 +962,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                     Target target = GetTarget(descriptor.Type);
 
-                    imageBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex);
+                    imageBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex, descriptor.Flags);
                 }
 
                 TextureManager.SetGraphicsImages(stage, imageBindings);

--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -6,6 +6,11 @@ namespace Ryujinx.Graphics.Gpu
     public static class GraphicsConfig
     {
         /// <summary>
+        /// Resolution scale.
+        /// </summary>
+        public static float ResScale = 1f;
+
+        /// <summary>
         /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.
         /// </summary>
         public static float MaxAnisotropy;

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -29,10 +29,20 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public TextureInfo Info { get; private set; }
 
+        /// <summary>
+        /// Host scale factor.
+        /// </summary>
+        public float ScaleFactor { get; private set; }
+
+        /// <summary>
+        /// Upscaling mode. Informs if a texture is scaled, or is eligible for scaling.
+        /// </summary>
+        public TextureScaleMode ScaleMode { get; private set; }
+
         private int _depth;
         private int _layers;
-        private readonly int _firstLayer;
-        private readonly int _firstLevel;
+        private int _firstLayer;
+        private int _firstLevel;
 
         private bool _hasData;
 
@@ -92,17 +102,24 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="sizeInfo">Size information of the texture</param>
         /// <param name="firstLayer">The first layer of the texture, or 0 if the texture has no parent</param>
         /// <param name="firstLevel">The first mipmap level of the texture, or 0 if the texture has no parent</param>
+        /// <param name="scaleFactor">The floating point scale factor to initialize with</param>
+        /// <param name="scaleMode">The scale mode to initialize with</param>
         private Texture(
-            GpuContext  context,
-            TextureInfo info,
-            SizeInfo    sizeInfo,
-            int         firstLayer,
-            int         firstLevel)
+            GpuContext       context,
+            TextureInfo      info,
+            SizeInfo         sizeInfo,
+            int              firstLayer,
+            int              firstLevel,
+            float            scaleFactor,
+            TextureScaleMode scaleMode)
         {
             InitializeTexture(context, info, sizeInfo);
 
             _firstLayer = firstLayer;
             _firstLevel = firstLevel;
+
+            ScaleFactor = scaleFactor;
+            ScaleMode = scaleMode;
 
             _hasData = true;
         }
@@ -113,13 +130,23 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="context">GPU context that the texture belongs to</param>
         /// <param name="info">Texture information</param>
         /// <param name="sizeInfo">Size information of the texture</param>
-        public Texture(GpuContext context, TextureInfo info, SizeInfo sizeInfo)
+        /// <param name="scaleMode">The scale mode to initialize with. If scaled, the texture's data is loaded immediately and scaled up</param>
+        public Texture(GpuContext context, TextureInfo info, SizeInfo sizeInfo, TextureScaleMode scaleMode)
         {
+            ScaleFactor = 1f; // Texture is first loaded at scale 1x.
+            ScaleMode = scaleMode;
+
             InitializeTexture(context, info, sizeInfo);
 
             TextureCreateInfo createInfo = TextureManager.GetCreateInfo(info, context.Capabilities);
 
-            HostTexture = _context.Renderer.CreateTexture(createInfo);
+            HostTexture = _context.Renderer.CreateTexture(createInfo, ScaleFactor);
+
+            if (scaleMode == TextureScaleMode.Scaled)
+            {
+                SynchronizeMemory(); // Load the data and then scale it up.
+                SetScale(GraphicsConfig.ResScale);
+            }
         }
 
         /// <summary>
@@ -162,7 +189,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 info,
                 sizeInfo,
                 _firstLayer + firstLayer,
-                _firstLevel + firstLevel);
+                _firstLevel + firstLevel,
+                ScaleFactor,
+                ScaleMode);
 
             TextureCreateInfo createInfo = TextureManager.GetCreateInfo(info, _context.Capabilities);
 
@@ -282,11 +311,154 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
-                ITexture newStorage = _context.Renderer.CreateTexture(createInfo);
+                ITexture newStorage = _context.Renderer.CreateTexture(createInfo, ScaleFactor);
 
                 HostTexture.CopyTo(newStorage, 0, 0);
 
                 ReplaceStorage(newStorage);
+            }
+        }
+
+        /// <summary>
+        /// Blacklists this texture from being scaled. Resets its scale to 1 if needed.
+        /// </summary>
+        public void BlacklistScale()
+        {
+            ScaleMode = TextureScaleMode.Blacklisted;
+            SetScale(1f);
+        }
+
+        /// <summary>
+        /// Propagates the scale between this texture and another to ensure they have the same scale.
+        /// If one texture is blacklisted from scaling, the other will become blacklisted too.
+        /// </summary>
+        /// <param name="other">The other texture</param>
+        public void PropagateScale(Texture other)
+        {
+            if (other.ScaleMode == TextureScaleMode.Blacklisted || ScaleMode == TextureScaleMode.Blacklisted)
+            {
+                BlacklistScale();
+                other.BlacklistScale();
+            }
+            else
+            {
+                // Prefer the configured scale if present. If not, prefer the max.
+                float targetScale = GraphicsConfig.ResScale;
+                float sharedScale = (ScaleFactor == targetScale || other.ScaleFactor == targetScale) ? targetScale : Math.Max(ScaleFactor, other.ScaleFactor);
+
+                SetScale(sharedScale);
+                other.SetScale(sharedScale);
+            }
+        }
+
+        /// <summary>
+        /// Helper method for copying our Texture2DArray texture to the given target, with scaling.
+        /// This creates temporary views for each array layer on both textures, copying each one at a time.
+        /// </summary>
+        /// <param name="target">The texture array to copy to</param>
+        private void CopyArrayScaled(ITexture target)
+        {
+            TextureInfo viewInfo = new TextureInfo(
+                Info.Address,
+                Info.Width,
+                Info.Height,
+                1,
+                Info.Levels,
+                Info.SamplesInX,
+                Info.SamplesInY,
+                Info.Stride,
+                Info.IsLinear,
+                Info.GobBlocksInY,
+                Info.GobBlocksInZ,
+                Info.GobBlocksInTileX,
+                Target.Texture2D,
+                Info.FormatInfo,
+                Info.DepthStencilMode,
+                Info.SwizzleR,
+                Info.SwizzleG,
+                Info.SwizzleB,
+                Info.SwizzleA);
+
+            TextureCreateInfo createInfo = TextureManager.GetCreateInfo(viewInfo, _context.Capabilities);
+
+            for (int i = 0; i < Info.DepthOrLayers; i++)
+            {
+                ITexture from = HostTexture.CreateView(createInfo, i, 0);
+                ITexture to = target.CreateView(createInfo, i, 0);
+
+                from.CopyTo(to, new Extents2D(0, 0, from.Width, from.Height), new Extents2D(0, 0, to.Width, to.Height), true);
+
+                from.Dispose();
+                to.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Sets the Scale Factor on this texture, and immediately recreates it at the correct size.
+        /// When a texture is resized, a scaled copy is performed from the old texture to the new one, to ensure no data is lost.
+        /// If scale is equivalent, this only propagates the blacklisted/scaled mode.
+        /// If called on a view, its storage is resized instead.
+        /// When resizing storage, all texture views are recreated.
+        /// </summary>
+        /// <param name="scale">The new scale factor for this texture</param>
+        public void SetScale(float scale)
+        {
+            TextureScaleMode newScaleMode = ScaleMode == TextureScaleMode.Blacklisted ? ScaleMode : TextureScaleMode.Scaled;
+
+            if (_viewStorage != this)
+            {
+                _viewStorage.ScaleMode = newScaleMode;
+                _viewStorage.SetScale(scale);
+                return;
+            }
+
+            if (ScaleFactor != scale)
+            {
+                Logger.PrintDebug(LogClass.Gpu, $"Rescaling {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()} to ({ScaleFactor} to {scale}). ");
+                TextureCreateInfo createInfo = TextureManager.GetCreateInfo(Info, _context.Capabilities);
+
+                ScaleFactor = scale;
+
+                ITexture newStorage = _context.Renderer.CreateTexture(createInfo, ScaleFactor);
+
+                if (Info.Target == Target.Texture2DArray)
+                {
+                    CopyArrayScaled(newStorage);
+                }
+                else
+                {
+                    HostTexture.CopyTo(newStorage, new Extents2D(0, 0, HostTexture.Width, HostTexture.Height), new Extents2D(0, 0, newStorage.Width, newStorage.Height), true);
+                }
+
+                Logger.PrintDebug(LogClass.Gpu, $"  Copy performed: {HostTexture.Width}x{HostTexture.Height} to {newStorage.Width}x{newStorage.Height}");
+
+                ReplaceStorage(newStorage);
+
+                // All views must be recreated against the new storage.
+
+                foreach (var view in _views)
+                {
+                    Logger.PrintDebug(LogClass.Gpu, $"  Recreating view {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()}.");
+                    view.ScaleFactor = scale;
+
+                    TextureCreateInfo viewCreateInfo = TextureManager.GetCreateInfo(view.Info, _context.Capabilities);
+
+                    ITexture newView = HostTexture.CreateView(viewCreateInfo, view._firstLayer - _firstLayer, view._firstLevel - _firstLevel);
+
+                    view.ReplaceStorage(newView);
+
+                    view.ScaleMode = newScaleMode;
+                }
+            }
+
+            if (ScaleMode != newScaleMode)
+            {
+                ScaleMode = newScaleMode;
+
+                foreach (var view in _views)
+                {
+                    view.ScaleMode = newScaleMode;
+                }
             }
         }
 
@@ -310,9 +482,14 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             int modifiedCount = _context.PhysicalMemory.QueryModified(Address, Size, ResourceName.Texture, _modifiedRanges);
 
-            if (modifiedCount == 0 && _hasData)
+            if (_hasData)
             {
-                return;
+                if (modifiedCount == 0)
+                {
+                    return;
+                }
+
+                BlacklistScale();
             }
 
             ReadOnlySpan<byte> data = _context.PhysicalMemory.GetSpan(Address, (int)Size);
@@ -432,6 +609,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void Flush()
         {
+            BlacklistScale();
             _context.PhysicalMemory.Write(Address, GetTextureDataFromGpu());
         }
 
@@ -445,6 +623,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>Host texture data</returns>
         private Span<byte> GetTextureDataFromGpu()
         {
+            BlacklistScale();
             Span<byte> data = HostTexture.GetData();
 
             if (Info.IsLinear)
@@ -980,10 +1159,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="parent">The parent texture</param>
         /// <param name="info">The new view texture information</param>
         /// <param name="hostTexture">The new host texture</param>
-        public void ReplaceView(Texture parent, TextureInfo info, ITexture hostTexture)
+        /// <param name="firstLayer">The first layer of the view</param>
+        /// <param name="firstLevel">The first level of the view</param>
+        public void ReplaceView(Texture parent, TextureInfo info, ITexture hostTexture, int firstLayer, int firstLevel)
         {
             ReplaceStorage(hostTexture);
 
+            _firstLayer = parent._firstLayer + firstLayer;
+            _firstLevel = parent._firstLevel + firstLevel;
             parent._viewStorage.AddView(this);
 
             SetInfo(info);
@@ -1075,7 +1258,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             // already deleted (views count is 0).
             if (_referenceCount == 0 && _views.Count == 0)
             {
-                DisposeTextures();
+                Dispose();
             }
         }
 
@@ -1088,8 +1271,6 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _arrayViewTexture?.Dispose();
             _arrayViewTexture = null;
-
-            Disposed?.Invoke(this);
         }
 
         /// <summary>
@@ -1098,6 +1279,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         public void Dispose()
         {
             DisposeTextures();
+
+            Disposed?.Invoke(this);
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingInfo.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingInfo.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Shader;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -38,11 +39,17 @@ namespace Ryujinx.Graphics.Gpu.Image
         public int CbufOffset { get; }
 
         /// <summary>
+        /// Flags from the texture descriptor that indicate how the texture is used.
+        /// </summary>
+        public TextureUsageFlags Flags { get; }
+
+        /// <summary>
         /// Constructs the texture binding information structure.
         /// </summary>
         /// <param name="target">The shader sampler target type</param>
         /// <param name="handle">The shader texture handle (read index into the texture constant buffer)</param>
-        public TextureBindingInfo(Target target, int handle)
+        /// <param name="flags">The texture's usage flags, indicating how it is used in the shader</param>
+        public TextureBindingInfo(Target target, int handle, TextureUsageFlags flags)
         {
             Target = target;
             Handle = handle;
@@ -51,6 +58,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             CbufSlot   = 0;
             CbufOffset = 0;
+
+            Flags = flags;
         }
 
         /// <summary>
@@ -59,7 +68,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="target">The shader sampler target type</param>
         /// <param name="cbufSlot">Constant buffer slot where the bindless texture handle is located</param>
         /// <param name="cbufOffset">Constant buffer offset of the bindless texture handle</param>
-        public TextureBindingInfo(Target target, int cbufSlot, int cbufOffset)
+        /// <param name="flags">The texture's usage flags, indicating how it is used in the shader</param>
+        public TextureBindingInfo(Target target, int cbufSlot, int cbufOffset, TextureUsageFlags flags)
         {
             Target = target;
             Handle = 0;
@@ -68,6 +78,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             CbufSlot   = cbufSlot;
             CbufOffset = cbufOffset;
+
+            Flags = flags;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -174,7 +174,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 swizzleB,
                 swizzleA);
 
-            if (IsDepthStencil(formatInfo.Format))
+            if (formatInfo.Format.IsDepthOrStencil())
             {
                 swizzleR = SwizzleComponent.Red;
                 swizzleG = SwizzleComponent.Red;
@@ -261,26 +261,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             return component == SwizzleComponent.Red ||
                    component == SwizzleComponent.Green;
-        }
-
-        /// <summary>
-        /// Checks if the texture format is a depth, stencil or depth-stencil format.
-        /// </summary>
-        /// <param name="format">Texture format</param>
-        /// <returns>True if the format is a depth, stencil or depth-stencil format, false otherwise</returns>
-        private static bool IsDepthStencil(Format format)
-        {
-            switch (format)
-            {
-                case Format.D16Unorm:
-                case Format.D24UnormS8Uint:
-                case Format.D24X8Unorm:
-                case Format.D32Float:
-                case Format.D32FloatS8Uint:
-                    return true;
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureScaleMode.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureScaleMode.cs
@@ -1,0 +1,14 @@
+﻿namespace Ryujinx.Graphics.Gpu.Image
+{
+    /// <summary>
+    /// The scale mode for a given texture.
+    /// Blacklisted textures cannot be scaled, Eligible textures have not been scaled yet,
+    /// and Scaled textures have been scaled already.
+    /// </summary>
+    enum TextureScaleMode
+    {
+        Eligible = 0,
+        Scaled = 1,
+        Blacklisted = 2
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
@@ -11,6 +11,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         None     = 0,
         IgnoreMs = 1 << 0,
         Strict   = 1 << 1 | Sampler,
-        Sampler  = 1 << 2
+        Sampler  = 1 << 2,
+        WithUpscale = 1 << 3
     }
 }

--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -146,7 +146,7 @@ namespace Ryujinx.Graphics.Gpu
             {
                 pt.AcquireCallback(_context, pt.UserObj);
 
-                Texture texture = _context.Methods.TextureManager.FindOrCreateTexture(pt.Info);
+                Texture texture = _context.Methods.TextureManager.FindOrCreateTexture(pt.Info, TextureSearchFlags.WithUpscale);
 
                 texture.SynchronizeMemory();
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBase.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBase.cs
@@ -1,5 +1,6 @@
 ﻿using OpenTK.Graphics.OpenGL;
 using Ryujinx.Graphics.GAL;
+using System;
 
 namespace Ryujinx.Graphics.OpenGL.Image
 {
@@ -9,15 +10,19 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         protected TextureCreateInfo Info { get; }
 
-        public int Width => Info.Width;
-        public int Height => Info.Height;
+        public int Width { get; }
+        public int Height { get; }
+        public float ScaleFactor { get; }
 
         public Target Target => Info.Target;
         public Format Format => Info.Format;
 
-        public TextureBase(TextureCreateInfo info)
+        public TextureBase(TextureCreateInfo info, float scaleFactor = 1f)
         {
             Info = info;
+            Width = (int)Math.Ceiling(Info.Width * scaleFactor);
+            Height = (int)Math.Ceiling(Info.Height * scaleFactor);
+            ScaleFactor = scaleFactor;
 
             Handle = GL.GenTexture();
         }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -33,6 +33,11 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
             ClearBufferMask mask = GetMask(src.Format);
 
+            if ((mask & (ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit)) != 0 || src.Format.IsInteger())
+            {
+                linearFilter = false;
+            }
+
             BlitFramebufferFilter filter = linearFilter
                 ? BlitFramebufferFilter.Linear
                 : BlitFramebufferFilter.Nearest;
@@ -54,6 +59,9 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 dstRegion.Y2,
                 mask,
                 filter);
+
+            Attach(FramebufferTarget.ReadFramebuffer, src.Format, 0);
+            Attach(FramebufferTarget.DrawFramebuffer, dst.Format, 0);
 
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopyUnscaled.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopyUnscaled.cs
@@ -15,15 +15,16 @@ namespace Ryujinx.Graphics.OpenGL.Image
             int srcLayer,
             int dstLayer,
             int srcLevel,
-            int dstLevel)
+            int dstLevel,
+            float scaleFactor = 1f)
         {
-            int srcWidth  = srcInfo.Width;
-            int srcHeight = srcInfo.Height;
+            int srcWidth  = (int)Math.Ceiling(srcInfo.Width * scaleFactor);
+            int srcHeight = (int)Math.Ceiling(srcInfo.Height * scaleFactor);
             int srcDepth  = srcInfo.GetDepthOrLayers();
             int srcLevels = srcInfo.Levels;
 
-            int dstWidth  = dstInfo.Width;
-            int dstHeight = dstInfo.Height;
+            int dstWidth  = (int)Math.Ceiling(dstInfo.Width * scaleFactor);
+            int dstHeight = (int)Math.Ceiling(dstInfo.Height * scaleFactor);
             int dstDepth  = dstInfo.GetDepthOrLayers();
             int dstLevels = dstInfo.Levels;
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
@@ -1,12 +1,14 @@
 using OpenTK.Graphics.OpenGL;
 using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
+using System;
 
 namespace Ryujinx.Graphics.OpenGL.Image
 {
     class TextureStorage
     {
         public int Handle { get; private set; }
+        public float ScaleFactor { get; private set; }
 
         public TextureCreateInfo Info { get; }
 
@@ -14,12 +16,13 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         private int _viewsCount;
 
-        public TextureStorage(Renderer renderer, TextureCreateInfo info)
+        public TextureStorage(Renderer renderer, TextureCreateInfo info, float scaleFactor)
         {
             _renderer = renderer;
             Info      = info;
 
             Handle = GL.GenTexture();
+            ScaleFactor = scaleFactor;
 
             CreateImmutableStorage();
         }
@@ -31,6 +34,9 @@ namespace Ryujinx.Graphics.OpenGL.Image
             GL.ActiveTexture(TextureUnit.Texture0);
 
             GL.BindTexture(target, Handle);
+
+            int width = (int)Math.Ceiling(Info.Width * ScaleFactor);
+            int height = (int)Math.Ceiling(Info.Height * ScaleFactor);
 
             FormatInfo format = FormatTable.GetFormatInfo(Info.Format);
 
@@ -52,7 +58,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget1d.Texture1D,
                         Info.Levels,
                         internalFormat,
-                        Info.Width);
+                        width);
                     break;
 
                 case Target.Texture1DArray:
@@ -60,8 +66,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget2d.Texture1DArray,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height);
+                        width,
+                        height);
                     break;
 
                 case Target.Texture2D:
@@ -69,8 +75,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget2d.Texture2D,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height);
+                        width,
+                        height);
                     break;
 
                 case Target.Texture2DArray:
@@ -78,8 +84,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget3d.Texture2DArray,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         Info.Depth);
                     break;
 
@@ -88,8 +94,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTargetMultisample2d.Texture2DMultisample,
                         Info.Samples,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         true);
                     break;
 
@@ -98,8 +104,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTargetMultisample3d.Texture2DMultisampleArray,
                         Info.Samples,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         Info.Depth,
                         true);
                     break;
@@ -109,8 +115,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget3d.Texture3D,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         Info.Depth);
                     break;
 
@@ -119,8 +125,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget2d.TextureCubeMap,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height);
+                        width,
+                        height);
                     break;
 
                 case Target.CubemapArray:
@@ -128,8 +134,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         (TextureTarget3d)All.TextureCubeMapArray,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         Info.Depth);
                     break;
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
             TextureStorage    parent,
             TextureCreateInfo info,
             int               firstLayer,
-            int               firstLevel) : base(info)
+            int               firstLevel) : base(info, parent.ScaleFactor)
         {
             _renderer = renderer;
             _parent   = parent;
@@ -101,7 +101,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 // So we emulate that here with a texture copy (see the first CopyTo overload).
                 // However right now it only does a single copy right after the view is created,
                 // so it doesn't work for all cases.
-                TextureView emulatedView = (TextureView)_renderer.CreateTexture(info);
+                TextureView emulatedView = (TextureView)_renderer.CreateTexture(info, ScaleFactor);
 
                 emulatedView._emulatedViewParent = this;
 
@@ -122,10 +122,10 @@ namespace Ryujinx.Graphics.OpenGL.Image
             {
                 if (_incompatibleFormatView == null)
                 {
-                    _incompatibleFormatView = (TextureView)_renderer.CreateTexture(Info);
+                    _incompatibleFormatView = (TextureView)_renderer.CreateTexture(Info, ScaleFactor);
                 }
 
-                TextureCopyUnscaled.Copy(_parent.Info, _incompatibleFormatView.Info, _parent.Handle, _incompatibleFormatView.Handle, FirstLayer, 0, FirstLevel, 0);
+                TextureCopyUnscaled.Copy(_parent.Info, _incompatibleFormatView.Info, _parent.Handle, _incompatibleFormatView.Handle, FirstLayer, 0, FirstLevel, 0, ScaleFactor);
 
                 return _incompatibleFormatView.Handle;
             }
@@ -137,7 +137,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
         {
             if (_incompatibleFormatView != null)
             {
-                TextureCopyUnscaled.Copy(_incompatibleFormatView.Info, _parent.Info, _incompatibleFormatView.Handle, _parent.Handle, 0, FirstLayer, 0, FirstLevel);
+                TextureCopyUnscaled.Copy(_incompatibleFormatView.Info, _parent.Info, _incompatibleFormatView.Handle, _parent.Handle, 0, FirstLayer, 0, FirstLevel, ScaleFactor);
             }
         }
 
@@ -145,7 +145,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
         {
             TextureView destinationView = (TextureView)destination;
 
-            TextureCopyUnscaled.Copy(Info, destinationView.Info, Handle, destinationView.Handle, 0, firstLayer, 0, firstLevel);
+            TextureCopyUnscaled.Copy(Info, destinationView.Info, Handle, destinationView.Handle, 0, firstLayer, 0, firstLevel, ScaleFactor);
 
             if (destinationView._emulatedViewParent != null)
             {
@@ -157,7 +157,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                     0,
                     destinationView.FirstLayer,
                     0,
-                    destinationView.FirstLevel);
+                    destinationView.FirstLevel,
+                    ScaleFactor);
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -21,6 +21,9 @@ namespace Ryujinx.Graphics.OpenGL
 
         public int Handle { get; private set; }
 
+        public int FragmentRenderScaleUniform { get; }
+        public int ComputeRenderScaleUniform { get; }
+
         public bool IsLinked { get; private set; }
 
         private int[] _ubBindingPoints;
@@ -162,6 +165,9 @@ namespace Ryujinx.Graphics.OpenGL
                     imageUnit++;
                 }
             }
+
+            FragmentRenderScaleUniform = GL.GetUniformLocation(Handle, "fp_renderScale");
+            ComputeRenderScaleUniform = GL.GetUniformLocation(Handle, "cp_renderScale");
         }
 
         public void Bind()

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -54,9 +54,9 @@ namespace Ryujinx.Graphics.OpenGL
             return new Sampler(info);
         }
 
-        public ITexture CreateTexture(TextureCreateInfo info)
+        public ITexture CreateTexture(TextureCreateInfo info, float scaleFactor)
         {
-            return info.Target == Target.TextureBuffer ? new TextureBuffer(info) : new TextureStorage(this, info).CreateDefaultView();
+            return info.Target == Target.TextureBuffer ? new TextureBuffer(info) : new TextureStorage(this, info, scaleFactor).CreateDefaultView();
         }
 
         public void DeleteBuffer(BufferHandle buffer)

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -65,11 +65,12 @@ namespace Ryujinx.Graphics.OpenGL
             GL.Clear(ClearBufferMask.ColorBufferBit);
 
             int srcX0, srcX1, srcY0, srcY1;
+            float scale = view.ScaleFactor;
 
             if (crop.Left == 0 && crop.Right == 0)
             {
                 srcX0 = 0;
-                srcX1 = view.Width;
+                srcX1 = (int)(view.Width / scale);
             }
             else
             {
@@ -80,12 +81,20 @@ namespace Ryujinx.Graphics.OpenGL
             if (crop.Top == 0 && crop.Bottom == 0)
             {
                 srcY0 = 0;
-                srcY1 = view.Height;
+                srcY1 = (int)(view.Height / scale);
             }
             else
             {
                 srcY0 = crop.Top;
                 srcY1 = crop.Bottom;
+            }
+
+            if (scale != 1f)
+            {
+                srcX0 = (int)(srcX0 * scale);
+                srcY0 = (int)(srcY0 * scale);
+                srcX1 = (int)Math.Ceiling(srcX1 * scale);
+                srcY1 = (int)Math.Ceiling(srcY1 * scale);
             }
 
             float ratioX = MathF.Min(1f, (_height * (float)NativeWidth)  / ((float)NativeHeight * _width));

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Graphics.Shader.IntermediateRepresentation;
+using Ryujinx.Graphics.Shader.StructuredIr;
 using Ryujinx.Graphics.Shader.Translation;
 using System.Collections.Generic;
 using System.Text;
@@ -73,6 +75,21 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             UpdateIndentation();
 
             AppendLine("}" + suffix);
+        }
+
+        public int FindTextureDescriptorIndex(AstTextureOperation texOp)
+        {
+            AstOperand operand = texOp.GetSource(0) as AstOperand;
+            bool bindless = (texOp.Flags & TextureFlags.Bindless) > 0;
+
+            int cBufSlot = bindless ? operand.CbufSlot : 0;
+            int cBufOffset = bindless ? operand.CbufOffset : 0;
+
+            return TextureDescriptors.FindIndex(descriptor => 
+                descriptor.Type == texOp.Type && 
+                descriptor.HandleIndex == texOp.Handle && 
+                descriptor.CbufSlot == cBufSlot &&
+                descriptor.CbufOffset == cBufOffset);
         }
 
         private void UpdateIndentation()

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
@@ -1,0 +1,7 @@
+﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex) {
+    float scale = cp_renderScale[samplerIndex];
+    if (scale == 1.0) {
+        return inputVec;
+    }
+    return ivec2(vec2(inputVec) * scale);
+}

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
@@ -1,0 +1,11 @@
+﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex) {
+    float scale = fp_renderScale[1 + samplerIndex];
+    if (scale == 1.0) {
+        return inputVec;
+    }
+    if (scale < 0.0) { // If less than 0, try interpolate between texels by using the screen position.
+        return ivec2(vec2(inputVec) * (-scale) + mod(gl_FragCoord.xy, -scale));
+    } else {
+        return ivec2(vec2(inputVec) * scale);
+    }
+}

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -185,8 +185,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     {
                         switch (value & ~3)
                         {
-                            case AttributeConsts.PositionX: return "gl_FragCoord.x";
-                            case AttributeConsts.PositionY: return "gl_FragCoord.y";
+                            case AttributeConsts.PositionX: return "(gl_FragCoord.x / fp_renderScale[0])";
+                            case AttributeConsts.PositionY: return "(gl_FragCoord.y / fp_renderScale[0])";
                             case AttributeConsts.PositionZ: return "gl_FragCoord.z";
                             case AttributeConsts.PositionW: return "gl_FragCoord.w";
                         }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -32,6 +32,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                 Operand src = Attribute(op.AttributeOffset + index * 4);
 
+                context.FlagAttributeRead(src.Value);
+
                 context.Copy(Register(rd), context.LoadAttribute(src, primVertex));
             }
         }
@@ -95,6 +97,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
         public static void Ipa(EmitterContext context)
         {
             OpCodeIpa op = (OpCodeIpa)context.CurrOp;
+
+            context.FlagAttributeRead(op.AttributeOffset);
 
             Operand res = Attribute(op.AttributeOffset);
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -283,11 +283,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         public static void Tld(EmitterContext context)
         {
+            context.UsedFeatures |= FeatureFlags.IntegerSampling;
+
             EmitTextureSample(context, TextureFlags.IntCoords);
         }
 
         public static void TldB(EmitterContext context)
         {
+            context.UsedFeatures |= FeatureFlags.IntegerSampling;
+
             EmitTextureSample(context, TextureFlags.IntCoords | TextureFlags.Bindless);
         }
 
@@ -427,6 +431,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                     return;
                 }
+
+                context.UsedFeatures |= FeatureFlags.IntegerSampling;
 
                 flags = ConvertTextureFlags(tldsOp.Target) | TextureFlags.IntCoords;
 

--- a/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
+++ b/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
@@ -8,6 +8,8 @@
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\ShuffleUp.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\ShuffleXor.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\SwizzleAdd.glsl" />
+    <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\TexelFetchScale_fp.glsl" />
+    <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\TexelFetchScale_cp.glsl" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ryujinx.Graphics.Shader/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Shader/TextureDescriptor.cs
@@ -13,6 +13,8 @@ namespace Ryujinx.Graphics.Shader
         public int CbufSlot   { get; }
         public int CbufOffset { get; }
 
+        public TextureUsageFlags Flags { get; set; }
+
         public TextureDescriptor(string name, SamplerType type, int handleIndex)
         {
             Name        = name;
@@ -23,6 +25,8 @@ namespace Ryujinx.Graphics.Shader
 
             CbufSlot   = 0;
             CbufOffset = 0;
+
+            Flags = TextureUsageFlags.None;
         }
 
         public TextureDescriptor(string name, SamplerType type, int cbufSlot, int cbufOffset)
@@ -35,6 +39,8 @@ namespace Ryujinx.Graphics.Shader
 
             CbufSlot   = cbufSlot;
             CbufOffset = cbufOffset;
+
+            Flags = TextureUsageFlags.None;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
+++ b/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Ryujinx.Graphics.Shader
+{
+    /// <summary>
+    /// Flags that indicate how a texture will be used in a shader.
+    /// </summary>
+    [Flags]
+    public enum TextureUsageFlags
+    {
+        None = 0,
+
+        // Integer sampled textures must be noted for resolution scaling.
+        ResScaleUnsupported = 1 << 0
+    }
+}

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -11,6 +11,8 @@ namespace Ryujinx.Graphics.Shader.Translation
         public Block  CurrBlock { get; set; }
         public OpCode CurrOp    { get; set; }
 
+        public FeatureFlags UsedFeatures { get; set; }
+
         public ShaderConfig Config { get; }
 
         private List<Operation> _operations;
@@ -38,6 +40,20 @@ namespace Ryujinx.Graphics.Shader.Translation
         public void Add(Operation operation)
         {
             _operations.Add(operation);
+        }
+
+        public void FlagAttributeRead(int attribute)
+        {
+            if (Config.Stage == ShaderStage.Fragment)
+            {
+                switch (attribute)
+                {
+                    case AttributeConsts.PositionX:
+                    case AttributeConsts.PositionY:
+                        UsedFeatures |= FeatureFlags.FragCoordXY;
+                        break;
+                }
+            }
         }
 
         public void MarkLabel(Operand label)

--- a/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
+++ b/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Ryujinx.Graphics.Shader.Translation
+{
+    /// <summary>
+    /// Features used by the shader that are important for the code generator to know in advance.
+    /// These typically change the declarations in the shader header.
+    /// </summary>
+    [Flags]
+    public enum FeatureFlags
+    {
+        None = 0,
+
+        // Affected by resolution scaling.
+        FragCoordXY     = 1 << 1,
+        IntegerSampling = 1 << 0
+    }
+}

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -22,6 +22,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public TranslationFlags Flags { get; }
 
+        public FeatureFlags UsedFeatures { get; set; }
+
         public ShaderConfig(IGpuAccessor gpuAccessor, TranslationFlags flags)
         {
             Stage             = ShaderStage.Compute;
@@ -34,6 +36,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             OmapDepth         = false;
             GpuAccessor       = gpuAccessor;
             Flags             = flags;
+            UsedFeatures      = FeatureFlags.None;
         }
 
         public ShaderConfig(ShaderHeader header, IGpuAccessor gpuAccessor, TranslationFlags flags)
@@ -48,6 +51,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             OmapDepth         = header.OmapDepth;
             GpuAccessor       = gpuAccessor;
             Flags             = flags;
+            UsedFeatures      = FeatureFlags.None;
         }
 
         public int GetDepthRegister()

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,7 @@
 {
-  "version": 10,
+  "version": 11,
+  "res_scale": 2,
+  "res_scale_custom": 1,
   "max_anisotropy": -1,
   "graphics_shaders_dump_path": "",
   "logging_enable_debug": false,

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -328,6 +328,11 @@ namespace Ryujinx.Ui
                 }
 
                 string dockedMode = ConfigurationState.Instance.System.EnableDockedMode ? "Docked" : "Handheld";
+                float scale = Graphics.Gpu.GraphicsConfig.ResScale;
+                if (scale != 1)
+                {
+                    dockedMode += $" ({scale}x)";
+                }
 
                 if (_ticks >= _ticksPerFrame)
                 {

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -390,9 +390,7 @@ namespace Ryujinx.Ui
 
                 HLE.Switch device = InitializeSwitchInstance();
 
-                // TODO: Move this somewhere else + reloadable?
-                Graphics.Gpu.GraphicsConfig.MaxAnisotropy   = ConfigurationState.Instance.Graphics.MaxAnisotropy;
-                Graphics.Gpu.GraphicsConfig.ShadersDumpPath = ConfigurationState.Instance.Graphics.ShadersDumpPath;
+                UpdateGraphicsConfig();
 
                 Logger.PrintInfo(LogClass.Application, $"Using Firmware Version: {_contentManager.GetCurrentFirmwareVersion()?.VersionString}");
 
@@ -603,6 +601,15 @@ namespace Ryujinx.Ui
                     appMetadata.TimePlayed += Math.Round(sessionTimePlayed, MidpointRounding.AwayFromZero);
                 });
             }
+        }
+
+        public static void UpdateGraphicsConfig()
+        {
+            int resScale = ConfigurationState.Instance.Graphics.ResScale;
+            float resScaleCustom = ConfigurationState.Instance.Graphics.ResScaleCustom;
+            Graphics.Gpu.GraphicsConfig.ResScale = (resScale == -1) ? resScaleCustom : resScale;
+            Graphics.Gpu.GraphicsConfig.MaxAnisotropy = ConfigurationState.Instance.Graphics.MaxAnisotropy;
+            Graphics.Gpu.GraphicsConfig.ShadersDumpPath = ConfigurationState.Instance.Graphics.ShadersDumpPath;
         }
 
         public static void SaveConfig()

--- a/Ryujinx/Ui/SettingsWindow.cs
+++ b/Ryujinx/Ui/SettingsWindow.cs
@@ -63,6 +63,8 @@ namespace Ryujinx.Ui
         [GUI] Entry        _addGameDirBox;
         [GUI] Entry        _graphicsShadersDumpPath;
         [GUI] ComboBoxText _anisotropy;
+        [GUI] ComboBoxText _resScaleCombo;
+        [GUI] Entry        _resScaleText;
         [GUI] ToggleButton _configureController1;
         [GUI] ToggleButton _configureController2;
         [GUI] ToggleButton _configureController3;
@@ -94,6 +96,8 @@ namespace Ryujinx.Ui
             _configureController7.Pressed += (sender, args) => ConfigureController_Pressed(sender, args, PlayerIndex.Player7);
             _configureController8.Pressed += (sender, args) => ConfigureController_Pressed(sender, args, PlayerIndex.Player8);
             _configureControllerH.Pressed += (sender, args) => ConfigureController_Pressed(sender, args, PlayerIndex.Handheld);
+
+            _resScaleCombo.Changed += (sender, args) => _resScaleText.Visible = _resScaleCombo.ActiveId == "-1";
 
             //Setup Currents
             if (ConfigurationState.Instance.Logger.EnableFileLog)
@@ -204,9 +208,12 @@ namespace Ryujinx.Ui
             _systemRegionSelect.SetActiveId(ConfigurationState.Instance.System.Region.Value.ToString());
             _audioBackendSelect.SetActiveId(ConfigurationState.Instance.System.AudioBackend.Value.ToString());
             _systemTimeZoneSelect.SetActiveId(timeZoneContentManager.SanityCheckDeviceLocationName());
+            _resScaleCombo.SetActiveId(ConfigurationState.Instance.Graphics.ResScale.Value.ToString());
             _anisotropy.SetActiveId(ConfigurationState.Instance.Graphics.MaxAnisotropy.Value.ToString());
 
             _custThemePath.Buffer.Text           = ConfigurationState.Instance.Ui.CustomThemePath;
+            _resScaleText.Buffer.Text            = ConfigurationState.Instance.Graphics.ResScaleCustom.Value.ToString();
+            _resScaleText.Visible                = _resScaleCombo.ActiveId == "-1";
             _graphicsShadersDumpPath.Buffer.Text = ConfigurationState.Instance.Graphics.ShadersDumpPath;
             _fsLogSpinAdjustment.Value           = ConfigurationState.Instance.System.FsGlobalAccessLogMode;
             _systemTimeOffset                    = ConfigurationState.Instance.System.SystemTimeOffset;
@@ -408,6 +415,12 @@ namespace Ryujinx.Ui
                 _gameDirsBoxStore.IterNext(ref treeIter);
             }
 
+            float resScaleCustom;
+            if (!float.TryParse(_resScaleText.Buffer.Text, out resScaleCustom) || resScaleCustom <= 0.0f)
+            {
+                resScaleCustom = 1.0f;
+            }
+
             ConfigurationState.Instance.Logger.EnableError.Value               = _errorLogToggle.Active;
             ConfigurationState.Instance.Logger.EnableWarn.Value                = _warningLogToggle.Active;
             ConfigurationState.Instance.Logger.EnableInfo.Value                = _infoLogToggle.Active;
@@ -435,8 +448,11 @@ namespace Ryujinx.Ui
             ConfigurationState.Instance.Ui.GameDirs.Value                      = gameDirs;
             ConfigurationState.Instance.System.FsGlobalAccessLogMode.Value     = (int)_fsLogSpinAdjustment.Value;
             ConfigurationState.Instance.Graphics.MaxAnisotropy.Value           = float.Parse(_anisotropy.ActiveId);
+            ConfigurationState.Instance.Graphics.ResScale.Value                = int.Parse(_resScaleCombo.ActiveId);
+            ConfigurationState.Instance.Graphics.ResScaleCustom.Value          = resScaleCustom;
 
             MainWindow.SaveConfig();
+            MainWindow.UpdateGraphicsConfig();
             MainWindow.ApplyTheme();
             Dispose();
         }

--- a/Ryujinx/Ui/SettingsWindow.glade
+++ b/Ryujinx/Ui/SettingsWindow.glade
@@ -1687,6 +1687,70 @@
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
+                                        <property name="label" translatable="yes">Resolution Scale:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_resScaleCombo">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
+                                        <property name="active_id">1</property>
+                                        <items>
+                                          <item id="1" translatable="yes">Native (720p/1080p)</item>
+                                          <item id="2" translatable="yes">2x (1440p/2160p)</item>
+                                          <item id="3" translatable="yes">3x (2160p/3240p)</item>
+                                          <item id="4" translatable="yes">4x (2880p/4320p)</item>
+                                          <item id="-1" translatable="yes">Custom (not recommended)</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="_resScaleText">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_text" translatable="yes">Floating point resolution scale, such as 1.5. Non-integral scales are more likely to cause issues or crash.</property>
+                                        <property name="valign">center</property>
+                                        <property name="caps_lock_warning">False</property>
+                                        <property name="placeholder-text">1.0</property>
+                                        <property name="input-purpose">GTK_INPUT_PURPOSE_NUMBER</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_top">5</property>
+                                    <property name="margin_bottom">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
                                         <property name="tooltip_text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
                                         <property name="label" translatable="yes">Anisotropic Filtering:</property>
                                       </object>
@@ -1722,7 +1786,7 @@
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
                                     <property name="padding">5</property>
-                                    <property name="position">0</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                               </object>

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -700,6 +700,27 @@
     }
   },
   "properties": {
+    "res_scale": {
+      "$id": "#/properties/res_scale",
+      "type": "integer",
+      "title": "Resolution Scale",
+      "description": "An integer scale applied to applicable render targets. Values 1-4, or -1 to use a custom floating point scale instead.",
+      "default": -1,
+      "examples": [
+        -1,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    "res_scale_custom": {
+      "$id": "#/properties/res_scale_custom",
+      "type": "number",
+      "title": "Custom Resolution Scale",
+      "description": "A custom floating point scale applied to applicable render targets. Only active when Resolution Scale is -1.",
+      "default": 1.0,
+    },
     "max_anisotropy": {
       "$id": "#/properties/max_anisotropy",
       "type": "integer",
@@ -1211,7 +1232,7 @@
             "button_sr": "Unbound"
           }
         }
-      ] 
+      ]
     },
     "controller_config": {
       "$id": "#/properties/controller_config",


### PR DESCRIPTION
* Initial implementation of Render Target Scaling

Works with most games I have. No GUI option right now, it is hardcoded.

Missing handling for texelFetch operation.

* Realtime Configuration, refactoring.

* texelFetch scaling on fragment shader (WIP)

* Improve Shader-Side changes.

* Fix potential crash when no color/depth bound

* Workaround random uses of textures in compute.

This was blacklisting textures in a few games despite causing no bugs. Will eventually add full support so this doesn't break anything.

* Fix scales oscillating when changing between non-native scales.

* Scaled textures on compute, cleanup, lazier uniform update.

* Cleanup.

* Fix stupidity

* Address Thog Feedback.

* Cover most of GDK's feedback (two comments remain)

* Fix bad rename

* Move IsDepthStencil to FormatExtensions, add docs.

* Fix default config, square texture detection.

* Three final fixes:

- Nearest copy when texture is integer format.
- Texture2D -> Texture3D copy correctly blacklists the texture before trying an unscaled copy (caused driver error)
- Discount small textures.

* Remove scale threshold.

Not needed right now - we'll see if we run into problems.

* All CPU modification blacklists scale.

* Fix comment.