### PR TITLE
Salieri: Add blacklist system and blacklist shaders using bindless

### DIFF
--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -32,6 +32,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public HashSet<int> TextureHandlesForCache { get; }
 
+        public bool DiskShaderCacheIncompatible { get; private set; }
+
         public ShaderConfig(IGpuAccessor gpuAccessor, TranslationFlags flags, TranslationCounts counts)
         {
             Stage                  = ShaderStage.Compute;
@@ -118,6 +120,11 @@ namespace Ryujinx.Graphics.Shader.Translation
         public void SetUsedFeature(FeatureFlags flags)
         {
             UsedFeatures |= flags;
+        }
+
+        public void MarkDiskShaderCacheIncompatible()
+        {
+            DiskShaderCacheIncompatible = true;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/TranslationFlags.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslationFlags.cs
@@ -7,9 +7,10 @@ namespace Ryujinx.Graphics.Shader.Translation
     {
         None = 0,
 
-        VertexA   = 1 << 0,
-        Compute   = 1 << 1,
-        Feedback  = 1 << 2,
-        DebugMode = 1 << 3
+        VertexA     = 1 << 0,
+        Compute     = 1 << 1,
+        Feedback    = 1 << 2,
+        DebugMode   = 1 << 3,
+        ShaderCache = 1 << 4,
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -17,6 +17,8 @@ namespace Ryujinx.Graphics.Shader.Translation
         public ShaderStage Stage => _config.Stage;
         public int Size => _config.Size;
 
+        public bool DiskShaderCacheIncompatible => _config.DiskShaderCacheIncompatible;
+
         public HashSet<int> TextureHandlesForCache => _config.TextureHandlesForCache;
 
         public IGpuAccessor GpuAccessor => _config.GpuAccessor;


### PR DESCRIPTION
Currently the shader cache doesn't have the right format to support
bindless textures correctly and may cache shaders that it cannot rebuild
after host invalidation.

This PR address the issue by blacklisting shaders using bindless
textures.

THis also support detection of already cached broken shader and handle removal
of those.